### PR TITLE
Fix Major Assignment Async Error

### DIFF
--- a/app/services/colleagueClientServices.js
+++ b/app/services/colleagueClientServices.js
@@ -81,12 +81,12 @@ exports.createNewStudentForUserId = async (userId) => {
         const newStudent = await Student.create(studentData);
 
         // create majors for student
-        newColleagueData.Majors.forEach(async (major) => {
+        for (const major of newColleagueData.Majors) {
             const majorData = await Major.findForOCMajorId(major);
             if (majorData) {
                 await Student.addMajor(newStudent.id, majorData.id);
             }
-        })
+        }
 
         return newStudent;
     }


### PR DESCRIPTION
Refactored colleagueClientServices createNewStudentForUserId method to use a for loop instead of a foreach when creating majors to avoid async/await error.